### PR TITLE
Fixed the error when field name translations are not given

### DIFF
--- a/lib/dm-validations-i18n.rb
+++ b/lib/dm-validations-i18n.rb
@@ -79,7 +79,12 @@ end
 class DataMapper::Validations::ValidationErrors
   class << self
     def default_error_message_with_localized_field_name(key, field, *values)
-      field = DataMapper::Validations::I18n.field_name_translator.translate(field)
+      translator = DataMapper::Validations::I18n.field_name_translator
+
+      if translator
+        field = translator.translate(field)
+      end
+
       @@default_error_messages[key] % [field, *values].flatten
     end
 

--- a/test/test_dm-validations-i18n.rb
+++ b/test/test_dm-validations-i18n.rb
@@ -20,17 +20,15 @@ class TestDmValidationsI18n < Test::Unit::TestCase
     end
   end
 
-  # context 'localized field names with callback' do
-  #   DataMapper::Validations::I18n.translate_field_name_with do |field_name|
-  #     assert_equal field_name, 'foo'
-  #   end
-  # end
-  # context 'localized field names with rails I18n.t' do
-  #   # mock I18n.t(field, "dm-validation")
-  #   DataMapper::Validations::I18n.translate_field_name_with :rails
-  # end
-
   context 'DataMapper::Validations::ValidationErrors.default_error_message' do
+    should "not localize field names if not asked to" do
+      # manually set to nil, beacuse this test might not be the first to run.
+      DataMapper::Validations::I18n.field_name_translator = nil
+
+      DataMapper::Validations::I18n.localize!('zh-TW')
+      assert_equal("height 無效", DataMapper::Validations::ValidationErrors.default_error_message(:invalid, :height))
+    end
+
     should "localize field names with Rails way: I18n.t is used." do
       # mock I18n.t
       class ::I18n


### PR DESCRIPTION
as title.

The default fallback is to do no translation at all.
